### PR TITLE
Revert "Exclude magic ID fields from being upserted. Otherwise hilo inse...

### DIFF
--- a/lib/insertBuilder.js
+++ b/lib/insertBuilder.js
@@ -46,8 +46,7 @@ module.exports = function (params, cb) {
 	if (params.upsert) {
 		// col = VALUES(col)
 		for (var i = fields.length; i--;)
-			if (fields[i] !== 'id')     //How about we not overwrite the existing id!
-				fields[i] += ' = VALUES(' + fields[i] + ')';
+			fields[i] += ' = VALUES(' + fields[i] + ')';
 
 		sql.push(fields.join(', '));
 	}


### PR DESCRIPTION
Reverts Mindflash/mysqlutil#10
Although this commit was preventing the id from changing in the DB, it was still returning the new id, even though that id never made it in. Code which depended on that returned id to actually be in the DB would fail.